### PR TITLE
SPI read_passive_target timeout

### DIFF
--- a/adafruit_pn532/spi.py
+++ b/adafruit_pn532/spi.py
@@ -51,12 +51,7 @@ _SPI_READY                     = const(0x01)
 def reverse_bit(num):
     """Turn an LSB byte to an MSB byte, and vice versa. Used for SPI as
     it is LSB for the PN532, but 99% of SPI implementations are MSB only!"""
-    result = 0
-    for _ in range(8):
-        result <<= 1
-        result += (num & 1)
-        num >>= 1
-    return result
+    return int('{:08b}'.format(num)[::-1], 2)
 
 class PN532_SPI(PN532):
     """Driver for the PN532 connected over SPI. Pass in a hardware or bitbang
@@ -83,12 +78,12 @@ class PN532_SPI(PN532):
         timestamp = time.monotonic()
         while (time.monotonic() - timestamp) < timeout:
             with self._spi as spi:
-                time.sleep(0.02)   # required
+                #time.sleep(0.02)   # required
                 spi.write_readinto(status, status) #pylint: disable=no-member
             if reverse_bit(status[1]) == 0x01:  # LSB data is read in MSB
                 return True      # Not busy anymore!
-            else:
-                time.sleep(0.01)  # pause a bit till we ask again
+            #else:
+            #    time.sleep(0.01)  # pause a bit till we ask again
         # We timed out!
         return False
 
@@ -100,12 +95,12 @@ class PN532_SPI(PN532):
         frame[0] = reverse_bit(_SPI_DATAREAD)
 
         with self._spi as spi:
-            time.sleep(0.02)   # required
+            #time.sleep(0.02)   # required
             spi.write_readinto(frame, frame) #pylint: disable=no-member
         for i, val in enumerate(frame):
             frame[i] = reverse_bit(val) # turn LSB data to MSB
-        if self.debug:
-            print("Reading: ", [hex(i) for i in frame[1:]])
+        #if self.debug:
+        #    print("Reading: ", [hex(i) for i in frame[1:]])
         return frame[1:]
 
     def _write_data(self, framebytes):
@@ -113,8 +108,8 @@ class PN532_SPI(PN532):
         # start by making a frame with data write in front,
         # then rest of bytes, and LSBify it
         rev_frame = [reverse_bit(x) for x in bytes([_SPI_DATAWRITE]) + framebytes]
-        if self.debug:
-            print("Writing: ", [hex(i) for i in rev_frame])
+        #if self.debug:
+        #    print("Writing: ", [hex(i) for i in rev_frame])
         with self._spi as spi:
-            time.sleep(0.02)   # required
+            #time.sleep(0.02)   # required
             spi.write(bytes(rev_frame)) #pylint: disable=no-member

--- a/adafruit_pn532/spi.py
+++ b/adafruit_pn532/spi.py
@@ -76,14 +76,14 @@ class PN532_SPI(PN532):
         status = bytearray([reverse_bit(_SPI_STATREAD), 0])
 
         timestamp = time.monotonic()
-        while (time.monotonic() - timestamp) < timeout:
-            with self._spi as spi:
-                #time.sleep(0.02)   # required
+        with self._spi as spi:
+            while (time.monotonic() - timestamp) < timeout:
+                time.sleep(0.02)   # required (not needed when tested on rPi 3)
                 spi.write_readinto(status, status) #pylint: disable=no-member
-            if reverse_bit(status[1]) == 0x01:  # LSB data is read in MSB
-                return True      # Not busy anymore!
-            #else:
-            #    time.sleep(0.01)  # pause a bit till we ask again
+                if reverse_bit(status[1]) == 0x01:  # LSB data is read in MSB
+                    return True      # Not busy anymore!
+                else: # (not needed when tested on rPi 3)
+                    time.sleep(0.01)  # pause a bit till we ask again
         # We timed out!
         return False
 
@@ -95,12 +95,12 @@ class PN532_SPI(PN532):
         frame[0] = reverse_bit(_SPI_DATAREAD)
 
         with self._spi as spi:
-            #time.sleep(0.02)   # required
+            time.sleep(0.02)   # required (not needed when tested on rPi 3)
             spi.write_readinto(frame, frame) #pylint: disable=no-member
         for i, val in enumerate(frame):
             frame[i] = reverse_bit(val) # turn LSB data to MSB
-        #if self.debug:
-        #    print("Reading: ", [hex(i) for i in frame[1:]])
+        if self.debug:
+            print("Reading: ", [hex(i) for i in frame[1:]])
         return frame[1:]
 
     def _write_data(self, framebytes):
@@ -108,8 +108,8 @@ class PN532_SPI(PN532):
         # start by making a frame with data write in front,
         # then rest of bytes, and LSBify it
         rev_frame = [reverse_bit(x) for x in bytes([_SPI_DATAWRITE]) + framebytes]
-        #if self.debug:
-        #    print("Writing: ", [hex(i) for i in rev_frame])
+        if self.debug:
+            print("Writing: ", [hex(i) for i in rev_frame])
         with self._spi as spi:
-            #time.sleep(0.02)   # required
+            time.sleep(0.02)   # required (not needed when tested on rPi 3)
             spi.write(bytes(rev_frame)) #pylint: disable=no-member


### PR DESCRIPTION
To address the issue described in https://github.com/adafruit/Adafruit_CircuitPython_PN532/issues/19:
Modified the `_wait_ready` function, by avoiding re-declaring the `with` statement each iteration of the `while` loop.