### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_pn532/adafruit_pn532.py
+++ b/adafruit_pn532/adafruit_pn532.py
@@ -54,7 +54,6 @@ from micropython import const
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PN532.git"
 
-# pylint: disable=bad-whitespace
 _PREAMBLE = const(0x00)
 _STARTCODE1 = const(0x00)
 _STARTCODE2 = const(0xFF)
@@ -163,7 +162,6 @@ _GPIO_P35 = const(5)
 
 _ACK = b"\x00\x00\xFF\x00\xFF\x00"
 _FRAME_START = b"\x00\x00\xFF"
-# pylint: enable=bad-whitespace
 
 
 def _reset(pin):

--- a/adafruit_pn532/i2c.py
+++ b/adafruit_pn532/i2c.py
@@ -43,7 +43,6 @@ from digitalio import Direction
 from micropython import const
 from adafruit_pn532.adafruit_pn532 import PN532, BusyError, _reset
 
-# pylint: disable=bad-whitespace
 _I2C_ADDRESS = const(0x24)
 
 

--- a/adafruit_pn532/spi.py
+++ b/adafruit_pn532/spi.py
@@ -42,7 +42,6 @@ import adafruit_bus_device.spi_device as spi_device
 from micropython import const
 from adafruit_pn532.adafruit_pn532 import PN532
 
-# pylint: disable=bad-whitespace
 _SPI_STATREAD = const(0x02)
 _SPI_DATAWRITE = const(0x01)
 _SPI_DATAREAD = const(0x03)


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.