### PR TITLE
revise ntag2xx_read_block() to return None on failure, update example

### DIFF
--- a/adafruit_pn532/adafruit_pn532.py
+++ b/adafruit_pn532/adafruit_pn532.py
@@ -489,10 +489,11 @@ class PN532:
 
     def ntag2xx_read_block(self, block_number):
         """Read a block of data from the card.  Block number should be the block
-        to read.  If the block is successfully read a bytearray of length 16 with
-        data starting at the specified block will be returned.  If the block is
-        not read then None will be returned.
+        to read.  If the block is successfully read the first 4 bytes (after the
+        leading 0x00 byte) will be returned.
+        If the block is not read then None will be returned.
         """
-        return self.mifare_classic_read_block(block_number)[
-            0:4
-        ]  # only 4 bytes per page
+        ntag2xx_block = self.mifare_classic_read_block(block_number)
+        if ntag2xx_block is not None:
+            return ntag2xx_block[0:4]  # only 4 bytes per page
+        return None

--- a/examples/pn532_readwrite_ntag2xx.py
+++ b/examples/pn532_readwrite_ntag2xx.py
@@ -67,7 +67,11 @@ data[0:4] = b"\xFE\xED\xBE\xEF"
 # Write 4 byte block.
 pn532.ntag2xx_write_block(6, data)
 # Read block #6
-print(
-    "Wrote to block 6, now trying to read that data:",
-    [hex(x) for x in pn532.ntag2xx_read_block(6)],
-)
+ntag2xx_block = pn532.ntag2xx_read_block(6)
+if ntag2xx_block is not None:
+    print(
+        "Wrote to block 6, now trying to read that data:",
+        [hex(x) for x in pn532.ntag2xx_read_block(6)],
+    )
+else:
+    print("Read failed - did you remove the card?")

--- a/examples/pn532_readwrite_ntag2xx.py
+++ b/examples/pn532_readwrite_ntag2xx.py
@@ -71,7 +71,7 @@ ntag2xx_block = pn532.ntag2xx_read_block(6)
 if ntag2xx_block is not None:
     print(
         "Wrote to block 6, now trying to read that data:",
-        [hex(x) for x in pn532.ntag2xx_read_block(6)],
+        [hex(x) for x in ntag2xx_block],
     )
 else:
     print("Read failed - did you remove the card?")


### PR DESCRIPTION
fixes #52
tested on Raspbery Pi with PN523 breakout