### PR TITLE
Add I2C address

### DIFF
--- a/adafruit_pn532/i2c.py
+++ b/adafruit_pn532/i2c.py
@@ -29,14 +29,16 @@ _I2C_ADDRESS = const(0x24)
 class PN532_I2C(PN532):
     """Driver for the PN532 connected over I2C."""
 
-    def __init__(self, i2c, *, irq=None, reset=None, req=None, debug=False):
+    def __init__(
+        self, i2c, address=_I2C_ADDRESS, *, irq=None, reset=None, req=None, debug=False
+    ):
         """Create an instance of the PN532 class using I2C. Note that PN532
         uses clock stretching. Optional IRQ pin (not used),
         resetp pin and debugging output.
         """
         self.debug = debug
         self._req = req
-        self._i2c = i2c_device.I2CDevice(i2c, _I2C_ADDRESS)
+        self._i2c = i2c_device.I2CDevice(i2c, address)
         super().__init__(debug=debug, irq=irq, reset=reset)
 
     def _wakeup(self):


### PR DESCRIPTION
For #49. Adds ability to specify alternate I2C address for PN532. 

Only tested as far as not breaking anything with current library and default address running `pn532_simpletest` example on a Feather M4:

```python
Adafruit CircuitPython 7.3.3 on 2022-08-29; Adafruit Feather M4 Express with samd51j19
>>> import pn532_simpletest
Found PN532 with firmware version: 1.6
Waiting for RFID/NFC card...
......Found card with UID: ['0x27', '0xe8', '0xca', '0x35']
.Found card with UID: ['0x27', '0xe8', '0xca', '0x35']
.Found card with UID: ['0x27', '0xe8', '0xca', '0x35']
.Found card with UID: ['0x27', '0xe8', '0xca', '0x35']
.Found card with UID: ['0x27', '0xe8', '0xca', '0x35']
.Found card with UID: ['0x27', '0xe8', '0xca', '0x35']
.Found card with UID: ['0x27', '0xe8', '0xca', '0x35']