### PR TITLE
Change UART timeout to seconds in examples

### DIFF
--- a/examples/pn532_readwrite_mifare.py
+++ b/examples/pn532_readwrite_mifare.py
@@ -44,7 +44,7 @@ pn532 = PN532_I2C(i2c, debug=False)
 # pn532 = PN532_SPI(spi, cs_pin, debug=False)
 
 # UART connection
-# uart = busio.UART(board.TX, board.RX, baudrate=115200, timeout=100)
+# uart = busio.UART(board.TX, board.RX, baudrate=115200, timeout=0.1)
 # pn532 = PN532_UART(uart, debug=False)
 
 ic, ver, rev, support = pn532.firmware_version

--- a/examples/pn532_readwrite_ntag2xx.py
+++ b/examples/pn532_readwrite_ntag2xx.py
@@ -40,7 +40,7 @@ cs_pin = DigitalInOut(board.D5)
 pn532 = PN532_SPI(spi, cs_pin, debug=False)
 
 # UART connection
-# uart = busio.UART(board.TX, board.RX, baudrate=115200, timeout=100)
+# uart = busio.UART(board.TX, board.RX, baudrate=115200, timeout=0.1)
 # pn532 = PN532_UART(uart, debug=False)
 
 ic, ver, rev, support = pn532.firmware_version

--- a/examples/pn532_simplelisten.py
+++ b/examples/pn532_simplelisten.py
@@ -46,7 +46,7 @@ pn532 = PN532_I2C(i2c, debug=False, reset=reset_pin, req=req_pin, irq=irq_pin)
 # pn532 = PN532_SPI(spi, cs_pin, debug=False)
 
 # UART connection
-# uart = busio.UART(board.TX, board.RX, baudrate=115200, timeout=100)
+# uart = busio.UART(board.TX, board.RX, baudrate=115200, timeout=0.1)
 # pn532 = PN532_UART(uart, debug=False)
 
 ic, ver, rev, support = pn532.firmware_version

--- a/examples/pn532_simpletest.py
+++ b/examples/pn532_simpletest.py
@@ -40,7 +40,7 @@ pn532 = PN532_I2C(i2c, debug=False, reset=reset_pin, req=req_pin)
 # pn532 = PN532_SPI(spi, cs_pin, debug=False)
 
 # UART connection
-# uart = busio.UART(board.TX, board.RX, baudrate=115200, timeout=100)
+# uart = busio.UART(board.TX, board.RX, baudrate=115200, timeout=0.1)
 # pn532 = PN532_UART(uart, debug=False)
 
 ic, ver, rev, support = pn532.firmware_version


### PR DESCRIPTION
Fixes #44. And possibly #46. Also, #58 is similar, but using Pyserial via an FTDI cable, which the example do not directly cover.

Looks like the timeout value used for UART in several of the examples was being set in milliseconds instead of seconds. So the read was waiting 100 seconds. May still be a response length mismatch issue, but relying on the timeout to end the read seems to work based on `pn532_simpletest` example in UART mode:
```python
Adafruit CircuitPython 7.3.3 on 2022-08-29; Adafruit Feather M4 Express with samd51j19
>>> import pn532_simpletest
Found PN532 with firmware version: 1.6
Waiting for RFID/NFC card...
......Found card with UID: ['0x56', '0x58', '0x8f', '0x7c']
.Found card with UID: ['0x56', '0x58', '0x8f', '0x7c']
.Found card with UID: ['0x56', '0x58', '0x8f', '0x7c']
.Found card with UID: ['0x56', '0x58', '0x8f', '0x7c']
.Found card with UID: ['0x56', '0x58', '0x8f', '0x7c']
```