### PR TITLE
pn532: bump InListPassiveTarget response_length to 64 to handle long ATS

### DIFF
--- a/adafruit_pn532/adafruit_pn532.py
+++ b/adafruit_pn532/adafruit_pn532.py
@@ -409,7 +409,7 @@ class PN532:
         card's UID. This reduces the amount of time spend checking for a card.
         """
         response = self.process_response(
-            _COMMAND_INLISTPASSIVETARGET, response_length=30, timeout=timeout
+            _COMMAND_INLISTPASSIVETARGET, response_length=64, timeout=timeout
         )
         # If no response is available return None to indicate no card is present.
         if response is None:


### PR DESCRIPTION
pn532: bump InListPassiveTarget response_length to 64 to handle long ATS

Some ISO14443-A/EMV cards return longer ATS in the 0x4A response.
The previous 30–44 byte bound can truncate and trigger checksum errors.
Using 64 provides safe headroom with no behavior change for shorter replies.


What changed
In get_passive_target() (106A path), increase:

response_length=30 
to:
response_length=64

Rationale
call_function(..., response_length=N) is an upper bound, not a strict size. Longer ATS payloads (ATSLen + ATS) can push total reply length past 30–44 bytes; truncation leads to the checksum mismatch. Using 64 is conservative and low-risk.  A value of 44 works well for me and fixed the error I was seeing, but I used 64 for future-proofing.

Backwards compatibility / risk
Very low. Only increases the allowed maximum response size for a single command; no API changes.